### PR TITLE
chore: 🔧 (renovate) `pnpm` のアップデートを automerge しないように修正

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,7 @@
     {
       "groupName": "all non-major dependencies",
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "excludePackagePatterns": ["pnpm"],
       "automerge": true
     }
   ]


### PR DESCRIPTION
## Related Issues

- close: #6 