### PR TITLE
`typescript` v5.5 で非推奨となる `tsconfig.json` のプロパティへの警告を無効化

### DIFF
--- a/apps/website/tsconfig.json
+++ b/apps/website/tsconfig.json
@@ -8,6 +8,7 @@
       }
     ],
     "baseUrl": "./",
+    "ignoreDeprecations": "5.0",
     "paths": {
       "@/*": ["./src/*"]
     },


### PR DESCRIPTION
- `typescript` v5.5 で非推奨となる `importsNotUsedAsValues` の代替として推奨される `verbatimModuleSyntax` を指定すると `next` のコンパイラに `isolatedModules` とは一緒に指定できないと言われ、`isolatedModules` をコードから削除すると `isolatedModules` が指定されていないよと勝手に追加された末にまた `isolatedModules` を指定するなと言われてしまったので、結局 `ignoreDeprecations` を指定することにしました :oroka:

## 参照

- https://github.com/microsoft/TypeScript/issues/53601
- https://github.com/vercel/next.js/issues/46509