### PR TITLE
`eslint` にてバグがあるとみられる rules を一部無効化

### DIFF
--- a/apps/website/.eslintrc.json
+++ b/apps/website/.eslintrc.json
@@ -7,6 +7,14 @@
       {
         "patterns": ["../"]
       }
-    ]
+    ],
+    // HACK: Temporarily disable it because enabling it takes a lot of time at lint. Possibly bug in the `https://github.com/francoismassart/eslint-plugin-tailwindcss`.
+    "tailwindcss/enforces-shorthand": "off",
+    "tailwindcss/no-contradicting-classname": "off"
+  },
+  "settings": {
+    "tailwindcss": {
+      "callees": ["twMerge"]
+    }
   }
 }


### PR DESCRIPTION
- ソースはないです。一個一個コメントアウトしたりしていったら見つかりました。:oroka:
- `eslint` と `eslint-plugin-tailwindcss` のバージョンを過去に遡っても直らないので、一時的にこれで対応します。

## Related Issues

- close #81 
