### PR TITLE
リモートでホストされている画像もぼかしプレースホルダー表示ができるようにした。

### DIFF
--- a/apps/website/src/core/component/image/image.presenter.tsx
+++ b/apps/website/src/core/component/image/image.presenter.tsx
@@ -1,10 +1,26 @@
 import NextImage from 'next/image';
-import { ComponentPropsWithRef, forwardRef, ForwardRefExoticComponent } from 'react';
+import type { ImageProps } from 'next/image';
+import { useMemo } from 'react';
+import { forwardRef, ForwardRefExoticComponent } from 'react';
 
-type ImageProps = ComponentPropsWithRef<typeof NextImage>;
+const isImageSourceRemote = (src: string | unknown): src is string => {
+  return typeof src === 'string';
+};
 
-export const Image: ForwardRefExoticComponent<ImageProps> = forwardRef<HTMLImageElement | null, Omit<ImageProps, 'ref'>>((props, ref) => (
-  <NextImage ref={ref} {...props} />
-));
+export const Image: ForwardRefExoticComponent<ImageProps> = forwardRef<HTMLImageElement | null, Omit<ImageProps, 'ref'>>(
+  ({ src, placeholder, blurDataURL, ...props }, ref) => {
+    // Refer: https://github.com/vercel/next.js/discussions/26168
+    const remoteBlurDataURL = useMemo(() => (isImageSourceRemote(src) ? `/_next/image?url=${encodeURIComponent(src)}&w=64&q=75` : undefined), [src]);
+    return (
+      <NextImage
+        src={src}
+        placeholder={(!!remoteBlurDataURL && 'blur') || placeholder}
+        blurDataURL={remoteBlurDataURL || blurDataURL}
+        ref={ref}
+        {...props}
+      />
+    );
+  },
+);
 
 Image.displayName = 'Image';


### PR DESCRIPTION
- close #193 

dataURIで埋め込まないとそこまでの効果がないかも

<img width="913" alt="image" src="https://github.com/astronomy-club-at-nitic/nitic-astronomy/assets/16751535/a8e17240-7404-4f3d-a8b9-871af2150d91">

```html
<img alt="カバー" fetchpriority="high" decoding="async" data-nimg="fill" class="relative object-cover" style="position: absolute; height: 100%; width: 100%; inset: 0px; color: transparent;" sizes="100vw" srcset="/_next/image?url=https%3A%2F%2Fimages.microcms-assets.io%2Fassets%2Fd75b4ca57e1d45c5a21a9a8baf25d56a%2Fba5fb1868ce74bf98e20428181810343%2Felevate-nYgy58eb9aw-unsplash.jpg&amp;w=640&amp;q=75 640w, /_next/image?url=https%3A%2F%2Fimages.microcms-assets.io%2Fassets%2Fd75b4ca57e1d45c5a21a9a8baf25d56a%2Fba5fb1868ce74bf98e20428181810343%2Felevate-nYgy58eb9aw-unsplash.jpg&amp;w=750&amp;q=75 750w, /_next/image?url=https%3A%2F%2Fimages.microcms-assets.io%2Fassets%2Fd75b4ca57e1d45c5a21a9a8baf25d56a%2Fba5fb1868ce74bf98e20428181810343%2Felevate-nYgy58eb9aw-unsplash.jpg&amp;w=828&amp;q=75 828w, /_next/image?url=https%3A%2F%2Fimages.microcms-assets.io%2Fassets%2Fd75b4ca57e1d45c5a21a9a8baf25d56a%2Fba5fb1868ce74bf98e20428181810343%2Felevate-nYgy58eb9aw-unsplash.jpg&amp;w=1080&amp;q=75 1080w, /_next/image?url=https%3A%2F%2Fimages.microcms-assets.io%2Fassets%2Fd75b4ca57e1d45c5a21a9a8baf25d56a%2Fba5fb1868ce74bf98e20428181810343%2Felevate-nYgy58eb9aw-unsplash.jpg&amp;w=1200&amp;q=75 1200w, /_next/image?url=https%3A%2F%2Fimages.microcms-assets.io%2Fassets%2Fd75b4ca57e1d45c5a21a9a8baf25d56a%2Fba5fb1868ce74bf98e20428181810343%2Felevate-nYgy58eb9aw-unsplash.jpg&amp;w=1920&amp;q=75 1920w, /_next/image?url=https%3A%2F%2Fimages.microcms-assets.io%2Fassets%2Fd75b4ca57e1d45c5a21a9a8baf25d56a%2Fba5fb1868ce74bf98e20428181810343%2Felevate-nYgy58eb9aw-unsplash.jpg&amp;w=2048&amp;q=75 2048w, /_next/image?url=https%3A%2F%2Fimages.microcms-assets.io%2Fassets%2Fd75b4ca57e1d45c5a21a9a8baf25d56a%2Fba5fb1868ce74bf98e20428181810343%2Felevate-nYgy58eb9aw-unsplash.jpg&amp;w=3840&amp;q=75 3840w" src="/_next/image?url=https%3A%2F%2Fimages.microcms-assets.io%2Fassets%2Fd75b4ca57e1d45c5a21a9a8baf25d56a%2Fba5fb1868ce74bf98e20428181810343%2Felevate-nYgy58eb9aw-unsplash.jpg&amp;w=3840&amp;q=75">
```